### PR TITLE
use existing spi baudrate instead of hardcoded

### DIFF
--- a/adafruit_tlc5947.py
+++ b/adafruit_tlc5947.py
@@ -158,7 +158,9 @@ class TLC5947:
             # Lock the SPI bus and configure it for the shift register.
             while not self._spi.try_lock():
                 pass
-            self._spi.configure(baudrate=self._spi.frequency, polarity=0, phase=0, bits=8)
+            self._spi.configure(
+                baudrate=self._spi.frequency, polarity=0, phase=0, bits=8
+            )
             # First ensure latch is low.
             self._latch.value = False
             # Write out the bits.

--- a/adafruit_tlc5947.py
+++ b/adafruit_tlc5947.py
@@ -158,7 +158,7 @@ class TLC5947:
             # Lock the SPI bus and configure it for the shift register.
             while not self._spi.try_lock():
                 pass
-            self._spi.configure(baudrate=1000000, polarity=0, phase=0, bits=8)
+            self._spi.configure(baudrate=self._spi.frequency, polarity=0, phase=0, bits=8)
             # First ensure latch is low.
             self._latch.value = False
             # Write out the bits.

--- a/adafruit_tlc5947.py
+++ b/adafruit_tlc5947.py
@@ -158,9 +158,7 @@ class TLC5947:
             # Lock the SPI bus and configure it for the shift register.
             while not self._spi.try_lock():
                 pass
-            self._spi.configure(
-                baudrate=self._spi.frequency, polarity=0, phase=0, bits=8
-            )
+
             # First ensure latch is low.
             self._latch.value = False
             # Write out the bits.


### PR DESCRIPTION
resolves #22. I don't have hardware to test it, but wouldn't anticipate problems since it's mostly the same as: [#14](https://github.com/adafruit/Adafruit_CircuitPython_TLC59711/pull/14) from the TLC59711 library.